### PR TITLE
Generic OAuth configuration and conditional namespace creation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,7 @@ variable "source_security_group" {
 }
 
 variable "database_storage_size" {
-  description = "Disk space to allocation for RDS instance"
+  description = "Disk space in GB to allocation for RDS instance"
   default     = 5
   type        = number
 }
@@ -90,7 +90,7 @@ variable "oauth_auto_login" {
 variable "ingress_enabled" {
   type        = bool
   default     = false
-  description = "Enable or disable creation of ingress resources"
+  description = "Enable or disable creation of Ingress resources"
 }
 
 variable "ingress_hostnames" {
@@ -102,7 +102,7 @@ variable "ingress_hostnames" {
 variable "root_domain" {
   type        = string
   default     = ""
-  description = "Root url for OAUTH authentication"
+  description = "Root URL for OAuth 2.0 authentication"
 }
 
 variable "ingress_cluster_issuer" {

--- a/variables.tf
+++ b/variables.tf
@@ -49,26 +49,9 @@ variable "database_storage_size" {
   type        = number
 }
 
-variable "oauth_github_client_id" {
-  description = "Github OAUTH client id"
-  type        = string
-}
-
-variable "oauth_github_client_secret" {
-  description = "Github OAUTH client secret"
-  type        = string
-}
-
-variable "oauth_github_team_ids" {
-  description = "Limit access to Grafan from the following teams"
-  type        = list(number)
-  default     = []
-}
-
-variable "oauth_github_organizations" {
-  description = "Limit access to Grafana from the following organizations"
-  type        = list(string)
-  default     = ["nuuday"]
+variable "oauth_config" {
+  description = "OAuth configuration map for grafana.ini. E.g. `{ auth.github = { ... } }`. See https://grafana.com/docs/grafana/latest/auth/overview/ for a complete list of possible properties for each provider."
+  default     = {}
 }
 
 variable "auth_enable_basic" {


### PR DESCRIPTION
**NOTE** This is a proposal. Feel free to merge if you agree in the approach. Merge and rebase is advised. Comments are welcome :slightly_smiling_face: 

There are a few ways of extending the module variables to support the different [OAuth providers supported by Grafana](https://grafana.com/docs/grafana/latest/auth/overview/).

This proposal changes the module signature to

```terraform
module "grafana" {
  source = "..."

  # Properties omitted for brevity

  auth_config = {
    auth.azuread = {
      name          = "TDC Group Azure AD"
      enabled       = true
      client_id     = "..."      
      client_secret = "..."
    }

    auth.github = {
      # ...
    }
  }
}