### PR TITLE
fix: don't lookup K8s namespaces to determine namespace creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -193,10 +193,8 @@ resource "aws_security_group_rule" "grafana-cluster-rules" {
   source_security_group_id = var.source_security_group
 }
 
-data "kubernetes_all_namespaces" "all" {}
-
 resource "kubernetes_namespace" "grafana" {
-  count = contains(data.kubernetes_all_namespaces.all.namespaces, local.namespace) ? 0 : 1
+  count = local.namespace == "kube-system" ? 0 : 1
 
   metadata {
     name = local.namespace

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "database_instance_type" {
 
 variable "namespace" {
   default     = "grafana"
-  description = "Kubernetes namespace to deploy to"
+  description = "Kubernetes namespace to deploy to. This will fail if the namespace already exists."
   type        = string
 }
 


### PR DESCRIPTION
This could otherwise result in this error

    Error: Get "http://localhost/api/v1/namespaces": dial tcp 127.0.0.1:80: connect: connection refused
      on .terraform/modules/grafana/main.tf line 196, in data "kubernetes_all_namespaces" "all":
     196: data "kubernetes_all_namespaces" "all" {}