### PR TITLE
chore: move to helm provider 2.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ terraform {
     }
     helm = {
       source = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 2.1"
     }
   }
 }


### PR DESCRIPTION
I've verified that the deployed resources are the same after upgrading from 2.0 to 2.1 and tainting the helm chart by doing a diff of a velero backup of all resources.